### PR TITLE
Add support for non-root execution

### DIFF
--- a/charts/example-v2/templates/deployment.yaml
+++ b/charts/example-v2/templates/deployment.yaml
@@ -23,6 +23,21 @@ spec:
       serviceAccountName: {{ template "example.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: init
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - cp -rf /etc/nginx/conf.d/* /conf.d
+          volumeMounts:
+            - name: config
+              mountPath: /conf.d
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -43,6 +58,20 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /etc/nginx/conf.d
+            - name: cache
+              mountPath: /var/cache/nginx
+            - name: run
+              mountPath: /var/run
+      volumes:
+        - name: cache
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: run
+          emptyDir: {}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/example-v2/templates/deployment.yaml
+++ b/charts/example-v2/templates/deployment.yaml
@@ -59,10 +59,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: config
-              mountPath: /etc/nginx/conf.d
             - name: cache
               mountPath: /var/cache/nginx
+            - name: config
+              mountPath: /etc/nginx/conf.d
             - name: run
               mountPath: /var/run
       volumes:

--- a/charts/example-v2/values.yaml
+++ b/charts/example-v2/values.yaml
@@ -24,6 +24,7 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  runAsUser: 1001
   runAsNonRoot: true
   privileged: false
   allowPrivilegeEscalation: false


### PR DESCRIPTION
Fixes CI/CD pipeline for https://github.com/bitnami/charts/pull/21590

Currently, the chart 'example-v2' fails to deploy due to permission errors caused by non-root settings.

This PR fixes the errors.